### PR TITLE
Emulated device title change.

### DIFF
--- a/ESP32.ino
+++ b/ESP32.ino
@@ -28,7 +28,7 @@ public:
   }
 
   bool start(BLECharacteristicCallbacks* callbacks) noexcept {
-    BLEDevice::init("Carista");
+    BLEDevice::init("OBDII");  // changed from "Carista"
     BLEDevice::setPower(ESP_PWR_LVL_P9);
 
     server = BLEDevice::createServer();


### PR DESCRIPTION
Changed the emulated device name from "Carista" to "OBDII" which allows cell phone OBDII reading applications to communicate with the ESP32-S3.

Makes it easier for the noobs to use.